### PR TITLE
closes #7 and #8

### DIFF
--- a/src/quick.ts
+++ b/src/quick.ts
@@ -50,13 +50,12 @@ export default function quick(
   }
   // if no key provided
   const partition = (arr: number[], left: number, right: number) => {
-    const pivot = arr[Math.floor((right + left) / 2)]; // middle
+    const pivot = arr[Math.floor((right + left) / 2)];
     if (typeof pivot !== 'number') {
       throw new Error('all iterable items must be of type number');
     }
 
     while (left <= right) {
-      // if (typeof arr[left] !== 'number' || typeof arr[right] !== 'number') return;
       while (arr[left] < pivot) {
         if (typeof arr[left] !== 'number') {
           throw new Error('all iterable items must be of type number');
@@ -79,9 +78,6 @@ export default function quick(
         arr[right] = temp;
         left++;
         right--;
-        if (typeof arr[left] !== 'number' || typeof arr[right] !== 'number') {
-          throw new Error('all iterable items must be of type number');
-        }
       }
     }
     return left;

--- a/test/quick.test.ts
+++ b/test/quick.test.ts
@@ -1,7 +1,7 @@
 import { quick } from '../src/index';
 
 describe('Quick sort', () => {
-  xit('should numerically order an unordered array', () => {
+  it('should numerically order an unordered array', () => {
     const exampleArr = [2, 3, 5, 6, 4, 2, 8, 1]; // leading 1 works, nothing else
     expect(quick(exampleArr)).toEqual(exampleArr.sort((a, b) => a - b));
   });
@@ -18,9 +18,9 @@ describe('Quick sort', () => {
     }
     expect(match).toBe(true);
   });
-  xit('should handle negative numbers okay', () => {
-    const exampleArr = [-2, 3, 5, 6, 4, 2, 8, 1];
-    expect(quick(exampleArr)).toEqual(exampleArr.sort((a, b) => a - b));
+  it('should handle negative numbers okay', () => {
+    const exampleArr = [-2, 3, -5, 6, 4, 2, 8, 1];
+    expect(quick(exampleArr, null)).toEqual(exampleArr.sort((a, b) => a - b));
   });
   it('should throw error if array is empty', () => {
     expect(() => quick([])).toThrow(Error);


### PR DESCRIPTION
this pr closes issues #7 and #8

- the bug came from redundantly type checking elements at array index that would sometimes dip below 0 for certain arrays
- for example some arays have their low and high pivots meet at 0, 0 and then one of them would move to -1, causing an error to be thrown
- simply removes this redundant element type checking for that location